### PR TITLE
Redirect Endpoint in Oauth Flow to ensure caller is Google

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -46,8 +46,9 @@ public class Auth : ControllerBase
     {
         string? code = queryParameters.TryGetValue("code", out string? result) ? result : null;
         string? error = queryParameters.TryGetValue("error", out string? result2) ? result2 : null;
+        string? state = queryParameters.TryGetValue("error", out string? result3) ? result3 : null;
 
-        var response = await _authService.GetRedirectGoogle(code, error);
+        var response = await _authService.GetRedirectGoogle(code, error, state);
 
         Console.WriteLine(response.Message);
 

--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -46,7 +46,7 @@ public class Auth : ControllerBase
     {
         string? code = queryParameters.TryGetValue("code", out string? result) ? result : null;
         string? error = queryParameters.TryGetValue("error", out string? result2) ? result2 : null;
-        string? state = queryParameters.TryGetValue("error", out string? result3) ? result3 : null;
+        string? state = queryParameters.TryGetValue("state", out string? result3) ? result3 : null;
 
         var response = await _authService.GetRedirectGoogle(code, error, state);
 

--- a/Controllers/PlatformConnectionController.cs
+++ b/Controllers/PlatformConnectionController.cs
@@ -67,8 +67,9 @@ public class PlatformConnectionController : ControllerBase
     {
         string? code = queryParameters.TryGetValue("code", out string? result) ? result : null;
         string? error = queryParameters.TryGetValue("error", out string? result2) ? result2 : null;
+        string? state = queryParameters.TryGetValue("error", out string? result3) ? result3 : null;
 
-        var response = await _platformConnectionService.GetRedirectYoutube(code, error);
+        var response = await _platformConnectionService.GetRedirectYoutube(code, error, state);
 
         Console.WriteLine(response.Message);
 

--- a/Controllers/PlatformConnectionController.cs
+++ b/Controllers/PlatformConnectionController.cs
@@ -67,7 +67,7 @@ public class PlatformConnectionController : ControllerBase
     {
         string? code = queryParameters.TryGetValue("code", out string? result) ? result : null;
         string? error = queryParameters.TryGetValue("error", out string? result2) ? result2 : null;
-        string? state = queryParameters.TryGetValue("error", out string? result3) ? result3 : null;
+        string? state = queryParameters.TryGetValue("state", out string? result3) ? result3 : null;
 
         var response = await _platformConnectionService.GetRedirectYoutube(code, error, state);
 

--- a/Services/AuthService/AuthService.cs
+++ b/Services/AuthService/AuthService.cs
@@ -73,7 +73,7 @@ namespace MediaTrackerAuthenticationService.Services.AuthService
                     //TODO figure out some way to do error state
                     Console.WriteLine("ISSUES" + error);
                     serviceResponse.Data = "http://localhost:5173/" + "?error=failed";
-                    throw new Exception("");
+                    throw new Exception(error);
                 }
 
                 if (string.IsNullOrEmpty(state) || state != _configuration["GoogleOauth:State"]){

--- a/Services/AuthService/AuthService.cs
+++ b/Services/AuthService/AuthService.cs
@@ -29,6 +29,8 @@ namespace MediaTrackerAuthenticationService.Services.AuthService
         private readonly AppDbContext _dbContext;
         private readonly IMapper _mapper;
 
+        private readonly IConfiguration _configuration;
+
         public AuthService(
             IRequestUrlBuilderService requestUrlBuilderService,
             ISessionTokenService sessionTokenService,
@@ -38,7 +40,8 @@ namespace MediaTrackerAuthenticationService.Services.AuthService
             HttpClient httpClient,
             IHttpContextAccessor httpContextAccessor,
             AppDbContext appDbContext,
-            IMapper mapper
+            IMapper mapper,
+            IConfiguration configuration
         )
         {
             _requestUrlBuilderService = requestUrlBuilderService;
@@ -50,6 +53,7 @@ namespace MediaTrackerAuthenticationService.Services.AuthService
             _httpContextAccessor = httpContextAccessor;
             _dbContext = appDbContext;
             _mapper = mapper;
+            _configuration = configuration;
         }
 
         public ServiceResponse<string> GetGoogle()
@@ -58,7 +62,7 @@ namespace MediaTrackerAuthenticationService.Services.AuthService
             return url;
         }
 
-        public async Task<ServiceResponse<string>> GetRedirectGoogle(string? code, string? error)
+        public async Task<ServiceResponse<string>> GetRedirectGoogle(string? code, string? error, string? state)
         {
             var serviceResponse = new ServiceResponse<string>();
 
@@ -69,7 +73,12 @@ namespace MediaTrackerAuthenticationService.Services.AuthService
                     //TODO figure out some way to do error state
                     Console.WriteLine("ISSUES" + error);
                     serviceResponse.Data = "http://localhost:5173/" + "?error=failed";
-                    throw new Exception(error);
+                    throw new Exception("");
+                }
+
+                if (string.IsNullOrEmpty(state) || state != _configuration["GoogleOauth:State"]){
+                    // Someone not Google has called this endpoint, They are not authorized
+                    throw new Exception("UnAuthorized call for this endpoint");
                 }
 
                 string accessToken = (await _httpRequestService.GetTokensGoogle(OauthRequestType.GoogleLogin, code)).Data!.access_token;

--- a/Services/AuthService/IAuthService.cs
+++ b/Services/AuthService/IAuthService.cs
@@ -5,7 +5,7 @@ namespace MediaTrackerAuthenticationService.Services.AuthService
     public interface IAuthService
     {
         ServiceResponse<string> GetGoogle();
-        Task<ServiceResponse<string>> GetRedirectGoogle(string? code, string? error);
+        Task<ServiceResponse<string>> GetRedirectGoogle(string? code, string? error, string? state);
 
         Task<ServiceResponse<string>> RefreshSession(int userId);
         Task<ServiceResponse<string>> LogoutSession(int userId);

--- a/Services/PlatformConnectionService/IPlatformConnectionService.cs
+++ b/Services/PlatformConnectionService/IPlatformConnectionService.cs
@@ -13,6 +13,6 @@ namespace MediaTrackerAuthenticationService.Services.PlatformConnectionService
             UpdatePlatformConnectionDto updatedPlatformConnection
         );
         ServiceResponse<string> GetYoutube();
-        Task<ServiceResponse<string>> GetRedirectYoutube(string? code, string? error);
+        Task<ServiceResponse<string>> GetRedirectYoutube(string? code, string? error, string? state);
     }
 }

--- a/Services/PlatformConnectionService/PlatformConnectionService.cs
+++ b/Services/PlatformConnectionService/PlatformConnectionService.cs
@@ -135,7 +135,7 @@ namespace MediaTrackerAuthenticationService.Services.PlatformConnectionService
             return serviceResponse;
         }
 
-        public async Task<ServiceResponse<string>> GetRedirectYoutube(string? code, string? error)
+        public async Task<ServiceResponse<string>> GetRedirectYoutube(string? code, string? error, string? state)
         {
             var serviceResponse = new ServiceResponse<string>();
 
@@ -145,11 +145,15 @@ namespace MediaTrackerAuthenticationService.Services.PlatformConnectionService
                 {
                     //figure out some way to do error state
                     Console.WriteLine("ISSUES" + error);
-
                     serviceResponse.Data = "https://google.com" + "?error=" + error;
-
                     throw new Exception(error);
                 }
+
+                if (string.IsNullOrEmpty(state) || state != _configuration["GoogleOauth:State"]){
+                    // Someone not Google has called this endpoint, They are not authorized
+                    throw new Exception("UnAuthorized call for this endpoint");
+                }
+
 
                 Console.WriteLine($"Authorization Code: {code}");
 

--- a/Services/RequestUrlBuilderService/RequestUrlBuilderService.cs
+++ b/Services/RequestUrlBuilderService/RequestUrlBuilderService.cs
@@ -23,6 +23,7 @@ namespace MediaTrackerAuthenticationService.Services.RequestUrlBuilderService
             string endpoint = _configuration["GoogleOauth:Endpoint:Auth"];
             string clientId = _configuration["GoogleOauth:ClientId"];
             string siteDomain = _configuration["Site:Domain"];
+            string stateSecret = _configuration["GoogleOauth:State"];
             string responseType = "code";
             string accessType = "offline";
             string prompt = "consent";
@@ -48,7 +49,8 @@ namespace MediaTrackerAuthenticationService.Services.RequestUrlBuilderService
                 + $"&scope={scope}"
                 + $"&response_type={responseType}"
                 + $"&access_type={accessType}"
-                + $"&prompt={prompt}";
+                + $"&prompt={prompt}"
+                + $"&state={stateSecret}";
 
             serviceResponse.Data = oauthUrl;
             return serviceResponse;


### PR DESCRIPTION
Added a state secret variable in Oauth communications to ensure only Google can call our Oauth hook/redirect endpoint